### PR TITLE
foreign-table-schema

### DIFF
--- a/server/drivers/postgres/index.js
+++ b/server/drivers/postgres/index.js
@@ -138,7 +138,7 @@ const SCHEMA_SQL = `
     join pg_catalog.pg_namespace as ns on ns.oid = cls.relnamespace
     join pg_catalog.pg_type as tp on tp.typelem = attr.atttypid
   where 
-    cls.relkind in ('r', 'v', 'm')
+    cls.relkind in ('r', 'v', 'm', 'f')
     and ns.nspname not in ('pg_catalog', 'pg_toast', 'information_schema')
     and not attr.attisdropped 
     and attr.attnum > 0


### PR DESCRIPTION
Updates shema query to get foreign tables too.  Use case is using steampipe.io in service mode, all tables are foreign tables.  